### PR TITLE
✨ Feat: 인증 API 개발

### DIFF
--- a/src/main/java/com/memorybox/MemoryboxCertApplication.java
+++ b/src/main/java/com/memorybox/MemoryboxCertApplication.java
@@ -1,7 +1,10 @@
 package com.memorybox;
 
+import com.memorybox.controller.CertificationController;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class MemoryboxCertApplication {
@@ -10,4 +13,12 @@ public class MemoryboxCertApplication {
         SpringApplication.run(MemoryboxCertApplication.class, args);
     }
 
+    @Bean
+    public CommandLineRunner run(CertificationController certificationController) {
+        return (String[] args) -> {
+            for (int userId = 1; userId <= 10; userId++) {
+                certificationController.addUserId(userId);
+            }
+        };
+    }
 }

--- a/src/main/java/com/memorybox/MemoryboxCertApplication.java
+++ b/src/main/java/com/memorybox/MemoryboxCertApplication.java
@@ -1,6 +1,6 @@
 package com.memorybox;
 
-import com.memorybox.controller.CertificationController;
+import com.memorybox.service.UserIdService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -14,10 +14,10 @@ public class MemoryboxCertApplication {
     }
 
     @Bean
-    public CommandLineRunner run(CertificationController certificationController) {
+    public CommandLineRunner run(UserIdService userIdService) {
         return (String[] args) -> {
             for (int userId = 1; userId <= 10; userId++) {
-                certificationController.addUserId(userId);
+                userIdService.addUserId(userId);
             }
         };
     }

--- a/src/main/java/com/memorybox/MemoryboxCertApplication.java
+++ b/src/main/java/com/memorybox/MemoryboxCertApplication.java
@@ -1,10 +1,7 @@
 package com.memorybox;
 
-import com.memorybox.service.UserIdService;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class MemoryboxCertApplication {
@@ -13,12 +10,4 @@ public class MemoryboxCertApplication {
         SpringApplication.run(MemoryboxCertApplication.class, args);
     }
 
-    @Bean
-    public CommandLineRunner run(UserIdService userIdService) {
-        return (String[] args) -> {
-            for (int userId = 1; userId <= 10; userId++) {
-                userIdService.addUserId(userId);
-            }
-        };
-    }
 }

--- a/src/main/java/com/memorybox/controller/CertificationController.java
+++ b/src/main/java/com/memorybox/controller/CertificationController.java
@@ -27,6 +27,10 @@ public class CertificationController {
                 .build();
     }
 
+    public void addUserId(int userId) {
+        userIdQueue.offer(userId);
+    }
+
     private String getUserId() {
         return userIdQueue.pop().toString();
     }
@@ -40,14 +44,3 @@ public class CertificationController {
                 .build();
     }
 }
-
-/*
-* 1. 프론트 특정 URL 접속 -> 기념일 발생 유저 번호의 쿠키를 발급해주는 페이지
-* 2. 인증 서버에 인증 요청 시 해당 쿠키 확인
-*  - 있으면 Special 유저 번호를 memorybox-user-id 쿠키에 담아주기
-*  - 없으면 Queue에서 꺼낸 유저 번호를 쿠키에 담아주기
-*
-* 쿠키가 있으면 그 쿠키 ID리턴 -> 이미 들어온 사람들 재활용
-* 없으면 쿠키생성해주고 리턴 -> 첫 발급
-*
-* */

--- a/src/main/java/com/memorybox/controller/CertificationController.java
+++ b/src/main/java/com/memorybox/controller/CertificationController.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.memorybox.util.UserIdCookieUtil.MEMORYBOX_SPECIAL_USER_COOKIE;
@@ -20,8 +20,8 @@ public class CertificationController {
     private final UserIdService userIdService;
     private final UserIdCookieUtil cookieUtil;
 
-    @GetMapping("/cert")
-    public ResponseEntity<?> getCert(@CookieValue(MEMORYBOX_SPECIAL_USER_COOKIE) String userId) {
+    @PostMapping("/cert")
+    public ResponseEntity<?> createCert(@CookieValue(MEMORYBOX_SPECIAL_USER_COOKIE) String userId) {
         if (StringUtils.isBlank(userId)) {
             userId = userIdService.getUserId();
         }
@@ -32,8 +32,8 @@ public class CertificationController {
                 .build();
     }
 
-    @GetMapping("/special-cert")
-    public ResponseEntity<?> getSpecialCert() {
+    @PostMapping("/special-cert")
+    public ResponseEntity<?> createSpecialCert() {
         String userId = userIdService.getSpecialUserId();
         ResponseCookie userIdCookie = cookieUtil.makeUserIdCookie(userId, true);
 

--- a/src/main/java/com/memorybox/controller/CertificationController.java
+++ b/src/main/java/com/memorybox/controller/CertificationController.java
@@ -14,11 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class CertificationController {
 
-    private final UserIdService userIdService;
     private static final long maxAgeSeconds = 60 * 60 * 24 * 30L;
+    public static final String MEMORYBOX_SPECIAL_USER_COOKIE = "memorybox-special-user";
+    public static final String MEMORYBOX_USER_ID_COOKIE = "memorybox-user-id";
+
+    private final UserIdService userIdService;
 
     @GetMapping("/cert")
-    public ResponseEntity<?> getCert(@CookieValue("memorybox-cert-cookie") String userId) {
+    public ResponseEntity<?> getCert(@CookieValue(MEMORYBOX_SPECIAL_USER_COOKIE) String userId) {
         if (StringUtils.isBlank(userId)) {
             userId = userIdService.getUserId();
         }
@@ -28,8 +31,27 @@ public class CertificationController {
                 .build();
     }
 
+    @GetMapping("/special-cert")
+    public ResponseEntity<?> getSpecialCert() {
+        String userId = userIdService.getSpecialUserId();
+        ResponseCookie userIdCookie = makeSpecialUserIdCookie(userId);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, userIdCookie.toString())
+                .build();
+    }
+
     private ResponseCookie makeUserIdCookie(String userId) {
-        return ResponseCookie.from("memorybox-userId", userId)
+        return ResponseCookie.from(MEMORYBOX_USER_ID_COOKIE, userId)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
+
+    private ResponseCookie makeSpecialUserIdCookie(String specialUserId) {
+        return ResponseCookie.from(MEMORYBOX_SPECIAL_USER_COOKIE, specialUserId)
                 .httpOnly(true)
                 .secure(true)
                 .path("/")

--- a/src/main/java/com/memorybox/controller/CertificationController.java
+++ b/src/main/java/com/memorybox/controller/CertificationController.java
@@ -1,5 +1,7 @@
 package com.memorybox.controller;
 
+import com.memorybox.service.UserIdService;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -8,31 +10,22 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.concurrent.ConcurrentLinkedDeque;
-
+@RequiredArgsConstructor
 @RestController
 public class CertificationController {
 
-    private final ConcurrentLinkedDeque<Integer> userIdQueue = new ConcurrentLinkedDeque<>();
+    private final UserIdService userIdService;
     private static final long maxAgeSeconds = 60 * 60 * 24 * 30L;
 
     @GetMapping("/cert")
     public ResponseEntity<?> getCert(@CookieValue("memorybox-cert-cookie") String userId) {
         if (StringUtils.isBlank(userId)) {
-            userId = getUserId();
+            userId = userIdService.getUserId();
         }
         ResponseCookie userIdCookie = makeUserIdCookie(userId);
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, userIdCookie.toString())
                 .build();
-    }
-
-    public void addUserId(int userId) {
-        userIdQueue.offer(userId);
-    }
-
-    private String getUserId() {
-        return userIdQueue.pop().toString();
     }
 
     private ResponseCookie makeUserIdCookie(String userId) {

--- a/src/main/java/com/memorybox/controller/CertificationController.java
+++ b/src/main/java/com/memorybox/controller/CertificationController.java
@@ -1,0 +1,53 @@
+package com.memorybox.controller;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+@RestController
+public class CertificationController {
+
+    private final ConcurrentLinkedDeque<Integer> userIdQueue = new ConcurrentLinkedDeque<>();
+    private static final long maxAgeSeconds = 60 * 60 * 24 * 30L;
+
+    @GetMapping("/cert")
+    public ResponseEntity<?> getCert(@CookieValue("memorybox-cert-cookie") String userId) {
+        if (StringUtils.isBlank(userId)) {
+            userId = getUserId();
+        }
+        ResponseCookie userIdCookie = makeUserIdCookie(userId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, userIdCookie.toString())
+                .build();
+    }
+
+    private String getUserId() {
+        return userIdQueue.pop().toString();
+    }
+
+    private ResponseCookie makeUserIdCookie(String userId) {
+        return ResponseCookie.from("memorybox-userId", userId)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
+}
+
+/*
+* 1. 프론트 특정 URL 접속 -> 기념일 발생 유저 번호의 쿠키를 발급해주는 페이지
+* 2. 인증 서버에 인증 요청 시 해당 쿠키 확인
+*  - 있으면 Special 유저 번호를 memorybox-user-id 쿠키에 담아주기
+*  - 없으면 Queue에서 꺼낸 유저 번호를 쿠키에 담아주기
+*
+* 쿠키가 있으면 그 쿠키 ID리턴 -> 이미 들어온 사람들 재활용
+* 없으면 쿠키생성해주고 리턴 -> 첫 발급
+*
+* */

--- a/src/main/java/com/memorybox/service/UserIdService.java
+++ b/src/main/java/com/memorybox/service/UserIdService.java
@@ -3,17 +3,20 @@ package com.memorybox.service;
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 @Service
 public class UserIdService {
     private final ConcurrentLinkedDeque<Integer> userIdQueue = new ConcurrentLinkedDeque<>();
+    private final ConcurrentLinkedDeque<Integer> specialIdQueue = new ConcurrentLinkedDeque<>();
 
     @PostConstruct
     private void init() {
         for (int userId = 1; userId <= 10; userId++) {
             userIdQueue.offer(userId);
         }
+        specialIdQueue.addAll(List.of(111, 112, 113));
     }
 
     public String getUserId() {
@@ -22,7 +25,10 @@ public class UserIdService {
         return userId.toString();
     }
 
-    public void addUserId(int userId) {
-        userIdQueue.offer(userId);
+    public String getSpecialUserId() {
+        Integer userId = specialIdQueue.pop();
+        specialIdQueue.offer(userId);
+        return userId.toString();
     }
+
 }

--- a/src/main/java/com/memorybox/service/UserIdService.java
+++ b/src/main/java/com/memorybox/service/UserIdService.java
@@ -1,5 +1,6 @@
 package com.memorybox.service;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -7,6 +8,13 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 @Service
 public class UserIdService {
     private final ConcurrentLinkedDeque<Integer> userIdQueue = new ConcurrentLinkedDeque<>();
+
+    @PostConstruct
+    private void init() {
+        for (int userId = 1; userId <= 10; userId++) {
+            userIdQueue.offer(userId);
+        }
+    }
 
     public String getUserId() {
         Integer userId = userIdQueue.pop();

--- a/src/main/java/com/memorybox/service/UserIdService.java
+++ b/src/main/java/com/memorybox/service/UserIdService.java
@@ -4,12 +4,12 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 @Service
 public class UserIdService {
-    private final ConcurrentLinkedDeque<Integer> userIdQueue = new ConcurrentLinkedDeque<>();
-    private final ConcurrentLinkedDeque<Integer> specialIdQueue = new ConcurrentLinkedDeque<>();
+    private final ConcurrentLinkedQueue<Integer> userIdQueue = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<Integer> specialIdQueue = new ConcurrentLinkedQueue<>();
 
     @PostConstruct
     private void init() {
@@ -20,13 +20,13 @@ public class UserIdService {
     }
 
     public String getUserId() {
-        Integer userId = userIdQueue.pop();
+        Integer userId = userIdQueue.poll();
         userIdQueue.offer(userId);
         return userId.toString();
     }
 
     public String getSpecialUserId() {
-        Integer userId = specialIdQueue.pop();
+        Integer userId = specialIdQueue.poll();
         specialIdQueue.offer(userId);
         return userId.toString();
     }

--- a/src/main/java/com/memorybox/service/UserIdService.java
+++ b/src/main/java/com/memorybox/service/UserIdService.java
@@ -1,0 +1,20 @@
+package com.memorybox.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+@Service
+public class UserIdService {
+    private final ConcurrentLinkedDeque<Integer> userIdQueue = new ConcurrentLinkedDeque<>();
+
+    public String getUserId() {
+        Integer userId = userIdQueue.pop();
+        userIdQueue.offer(userId);
+        return userId.toString();
+    }
+
+    public void addUserId(int userId) {
+        userIdQueue.offer(userId);
+    }
+}

--- a/src/main/java/com/memorybox/util/UserIdCookieUtil.java
+++ b/src/main/java/com/memorybox/util/UserIdCookieUtil.java
@@ -1,0 +1,22 @@
+package com.memorybox.util;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserIdCookieUtil {
+    public static final String MEMORYBOX_SPECIAL_USER_COOKIE = "memorybox-special-user";
+    public static final String MEMORYBOX_USER_ID_COOKIE = "memorybox-user-id";
+    private static final long maxAgeSeconds = 60 * 60 * 24 * 30L;
+
+    public ResponseCookie makeUserIdCookie(String userId, boolean isSpecialUser) {
+        String cookieName = isSpecialUser ? MEMORYBOX_SPECIAL_USER_COOKIE : MEMORYBOX_USER_ID_COOKIE;
+
+        return ResponseCookie.from(cookieName, userId)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
+}


### PR DESCRIPTION
## 인증 시퀀스
1. 시연자(Special) 유저는 특별한 UserId 쿠키(special cookie)를 발급 받기 위한 페이지에 접근한다.
    - 프론트에서 Special Cookie 발급을 위한 페이지를 별도로 만들어야 한다.
    - 해당 페이지에서 GET /special-cert API를 호출하여 Special Cookie를 발급받는다. 
2. 이후 일반 UserId 발급 API를 호출 시, Special Cookie 유무에 따라 UserId를 발급 받는다.

## 작업 내용
- 시연자용(Special) UserId, 일반 UserId 발급 API 개발
- 시연자용 UserId 발급을 위해서 별도의 페이지 생성 필요
- 더미데이터가 있을 경우에만 정상 작동하는 로직 (이후 더미데이터에 맞춰 상수 값 변경 필요)
    - 일반 UserId: 1-10
    - Special(시연자) UserId: 111, 112, 113