### PR TITLE
✨ Feat: 인증 로직 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,7 @@ repositories {
 }
 
 dependencies {
-//    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
-//    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
-//    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/deployment/deploy.yaml
+++ b/deployment/deploy.yaml
@@ -69,3 +69,25 @@ spec:
     - name: memorybox-cert
       port: 8080
       targetPort: 8080
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: memorybox
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: memorybox-ikujo.165.192.105.60.nip.io
+      http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: memorybox-cert
+                port:
+                  number: 8080

--- a/src/main/java/com/memorybox/MemoryboxCertApplication.java
+++ b/src/main/java/com/memorybox/MemoryboxCertApplication.java
@@ -2,7 +2,9 @@ package com.memorybox;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class MemoryboxCertApplication {
 

--- a/src/main/java/com/memorybox/domain/cashbox/entity/CashBox.java
+++ b/src/main/java/com/memorybox/domain/cashbox/entity/CashBox.java
@@ -1,0 +1,75 @@
+package com.memorybox.domain.cashbox.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class CashBox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long userId;
+
+    @Column
+    private String name;
+
+    @Column
+    private String description;
+
+    @Column
+    private String thumbnail;
+
+    @Column
+    private String accountNum;
+
+    @Column
+    int balance;
+
+    @Column
+    private String productName;
+
+    @Column
+    private long coreBankId;
+
+    @CreatedDate
+    @Column
+    private LocalDateTime createdAt;
+
+    @Column
+    private LocalDate startDate;
+
+    @Column
+    private Boolean maturityEnabled;
+
+    @Column
+    private LocalDate maturityDate;
+
+    @Builder
+    public CashBox(Long userId, String name, String description, String thumbnail, String accountNum, int balance, String productName, long coreBankId, LocalDateTime createdAt, LocalDate startDate, Boolean maturityEnabled, LocalDate maturityDate) {
+        this.userId = userId;
+        this.name = name;
+        this.description = description;
+        this.thumbnail = thumbnail;
+        this.accountNum = accountNum;
+        this.balance = balance;
+        this.productName = productName;
+        this.coreBankId = coreBankId;
+        this.createdAt = createdAt;
+        this.startDate = startDate;
+        this.maturityEnabled = maturityEnabled;
+        this.maturityDate = maturityDate;
+    }
+}

--- a/src/main/java/com/memorybox/domain/cashbox/repository/CashBoxRepository.java
+++ b/src/main/java/com/memorybox/domain/cashbox/repository/CashBoxRepository.java
@@ -1,0 +1,7 @@
+package com.memorybox.domain.cashbox.repository;
+
+import com.memorybox.domain.cashbox.entity.CashBox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CashBoxRepository extends JpaRepository<CashBox, Long> {
+}

--- a/src/main/java/com/memorybox/domain/corebank/entity/CoreBank.java
+++ b/src/main/java/com/memorybox/domain/corebank/entity/CoreBank.java
@@ -1,0 +1,57 @@
+package com.memorybox.domain.corebank.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class CoreBank {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="id")
+    private Long id;
+
+    private long userId;
+
+    private String accountNum;
+
+    private int balance;
+
+    private String receivedAccount;
+
+    private String productName;
+
+    private LocalDate startDate;
+
+    private LocalDate maturityDate;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Builder
+    public CoreBank(Long id, String accountNum, int balance, String receivedAccount, String productName,
+                    LocalDate startDate, LocalDate maturityDate, LocalDateTime createdAt, long userId){
+        this.id = id;
+        this.userId = userId;
+        this.accountNum = accountNum;
+        this.balance = balance;
+        this.receivedAccount = receivedAccount;
+        this.productName = productName;
+        this.startDate = startDate;
+        this.maturityDate = maturityDate;
+        this.createdAt = createdAt;
+    }
+
+    public int updateBalance(int money){
+        balance += money;
+        return balance;
+    }
+}

--- a/src/main/java/com/memorybox/domain/corebank/repository/CoreBankRepository.java
+++ b/src/main/java/com/memorybox/domain/corebank/repository/CoreBankRepository.java
@@ -1,0 +1,7 @@
+package com.memorybox.domain.corebank.repository;
+
+import com.memorybox.domain.corebank.entity.CoreBank;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoreBankRepository extends JpaRepository<CoreBank, Long> {
+}

--- a/src/main/java/com/memorybox/domain/memory/entity/Image.java
+++ b/src/main/java/com/memorybox/domain/memory/entity/Image.java
@@ -1,0 +1,14 @@
+package com.memorybox.domain.memory.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Embeddable
+public class Image {
+    @Column
+    private String imageName;
+}

--- a/src/main/java/com/memorybox/domain/memory/entity/Memory.java
+++ b/src/main/java/com/memorybox/domain/memory/entity/Memory.java
@@ -1,0 +1,57 @@
+package com.memorybox.domain.memory.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Memory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private long cashBoxId;
+
+    @Column
+    private String title;
+
+    @Column
+    private String content;
+
+    @Column
+    private int depositAmount;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "image",
+            joinColumns = @JoinColumn(name = "memory_id"))
+    @OrderColumn(name = "line_idx")
+    private List<Image> images;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Memory(long cashBoxId, String title, String content, int depositAmount, List<String> images) {
+        this.cashBoxId = cashBoxId;
+        this.title = title;
+        this.content = content;
+        this.depositAmount = depositAmount;
+        saveImages(images);
+    }
+
+    private void saveImages(List<String> imageNames) {
+        this.images = imageNames.stream()
+                .map(Image::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/memorybox/domain/memory/repository/MemoryRepository.java
+++ b/src/main/java/com/memorybox/domain/memory/repository/MemoryRepository.java
@@ -1,0 +1,7 @@
+package com.memorybox.domain.memory.repository;
+
+import com.memorybox.domain.memory.entity.Memory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoryRepository extends JpaRepository<Memory, Long> {
+}

--- a/src/main/java/com/memorybox/domain/user/entity/User.java
+++ b/src/main/java/com/memorybox/domain/user/entity/User.java
@@ -1,0 +1,18 @@
+package com.memorybox.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+}

--- a/src/main/java/com/memorybox/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/memorybox/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.memorybox.domain.user.repository;
+
+import com.memorybox.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/memorybox/service/DummyDataService.java
+++ b/src/main/java/com/memorybox/service/DummyDataService.java
@@ -1,0 +1,145 @@
+package com.memorybox.service;
+
+import com.memorybox.domain.cashbox.entity.CashBox;
+import com.memorybox.domain.cashbox.repository.CashBoxRepository;
+import com.memorybox.domain.corebank.entity.CoreBank;
+import com.memorybox.domain.corebank.repository.CoreBankRepository;
+import com.memorybox.domain.memory.entity.Memory;
+import com.memorybox.domain.memory.repository.MemoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class DummyDataService {
+
+    public static final int N_CASH_BOX = 3;
+    public static final int N_CORE_BANK = 3;
+    public static final int N_MEMORY = 3;
+
+    private final CashBoxRepository cashBoxRepository;
+    private final CoreBankRepository coreBankRepository;
+    private final MemoryRepository memoryRepository;
+
+    @Async
+    @Transactional
+    public void saveDummyData(Long userId) {
+        //TODO 저금통 3개 생성 + 계좌 3개 생성, 각 저금통에 추억 3개씩 넣기
+        List<Long> coreBankIdList = saveCoreBankData(userId);
+        List<Long> cashBoxIdList = saveCashBoxData(userId, coreBankIdList);
+        saveMemoryData(cashBoxIdList);
+    }
+
+    private List<Long> saveCoreBankData(Long userId) {
+        //========= 더미데이터 ============
+        String[] accountNums = {"21702448796571", "21702479654744", "21702446796255"};
+        int[] bals = {6834000, 535000, 8865767};
+        String[] receivedAccs = {"6762050469586037801", "3557490054400654", "6334358568642629"};
+        String[] productNames = {"특별한 적금", "특별한 적금", "특별한 적금"};
+        LocalDate[] startDates = {
+                LocalDate.of(2023, 1, 22),
+                LocalDate.of(2021, 12, 27),
+                LocalDate.of(2022, 5, 16)};
+        LocalDate[] maturityDates = {
+                LocalDate.of(2024, 5, 4),
+                LocalDate.of(2023, 1, 22),
+                LocalDate.of(2024, 6, 21),};
+
+        //========= 저장 ============
+        List<Long> coreBankIdList = new ArrayList<>();
+        for (int i = 0; i < N_CORE_BANK; i++) {
+            CoreBank coreBank = CoreBank.builder()
+                    .userId(userId)
+                    .accountNum(accountNums[i])
+                    .balance(bals[i])
+                    .receivedAccount(receivedAccs[i])
+                    .productName(productNames[i])
+                    .startDate(startDates[i])
+                    .maturityDate(maturityDates[i])
+                    .build();
+            coreBankIdList.add(coreBankRepository.save(coreBank).getId());
+        }
+        return coreBankIdList;
+    }
+
+    private List<Long> saveCashBoxData(Long userId, List<Long> coreBankIdList) {
+        //========= 더미데이터 ============
+        String[] names = {"우리 지윤-어린이집", "우리 진아-유치원", "우리현교 - 어린이집"};
+        String[] descriptions = {"지윤이 성장일지", "귀여운 진아 유치원때", "우리현교"};
+        String[] thumbnails = {
+                "https://robohash.org/nonetet.png?size=50x50&set=set1",
+                "https://robohash.org/ullamvoluptatesnihil.png?size=50x50&set=set1",
+                "https://robohash.org/minimaquiaaut.png?size=50x50&set=set1"};
+        String[] accountNums = {"21702448796571", "21702479654744", "21702446796255"};
+        int[] balances = {6834000, 535000, 8865767};
+        String[] productNames = {"특별한 적금", "특별한 적금", "특별한 적금"};
+        LocalDate[] startDates = {
+                LocalDate.of(2023, 1, 22),
+                LocalDate.of(2021, 12, 27),
+                LocalDate.of(2022, 5, 16)};
+        boolean[] maturityEnableds = {false, true, false};
+        LocalDate[] maturityDates = {
+                LocalDate.of(2024, 5, 4),
+                LocalDate.of(2023, 1, 22),
+                LocalDate.of(2024, 6, 21),};
+
+        //========= 저장 ============
+        List<Long> cashBoxIdList = new ArrayList<>();
+        for (int i = 0; i < N_CASH_BOX; i++) {
+            CashBox cashBox = CashBox.builder()
+                    .userId(userId)
+                    .name(names[i])
+                    .description(descriptions[i])
+                    .thumbnail(thumbnails[i])
+                    .accountNum(accountNums[i])
+                    .balance(balances[i])
+                    .productName(productNames[i])
+                    .coreBankId(coreBankIdList.get(i))
+                    .startDate(startDates[i])
+                    .maturityEnabled(maturityEnableds[i])
+                    .maturityDate(maturityDates[i])
+                    .build();
+            cashBoxIdList.add(cashBoxRepository.save(cashBox).getId());
+        }
+        return cashBoxIdList;
+    }
+
+    private void saveMemoryData(List<Long> cashBoxIdList) {
+        //========= 더미데이터 ============
+        String[] titles = {};
+        String[] contents = {
+                "오늘 공원에 와서 그런지 지윤이가 정말 신났다. 지윤이가 신나서 웃는 모습은 역시 너무 귀엽네. 이제 그네도 탈줄 알고 작은 모래시계로도 놀고. 앞으로도 이렇게 자연과 놀이로 가득찬 순간들이 계속되게 엄마가 노력할게. 지윤이의 미소와 행복이 항상 지속되길! \uD83C\uDF08\uD83D\uDE0A",
+        "오늘은 크리스마스 날, 지윤이가 크리스마스 트리를 열심히 꾸미고 있는 모습! 작은 손에는 반짝이는 장식품을 들고, 설렘 가득한 눈빛으로 트리에 장식을 하고 있는게  너무 예쁘네.\n" +
+                "산타할아버지에게 받고 싶은 소원을 빌며 잤는데 어떤 소원일지 궁금하다. 크리스마스 분위기 속에서 지윤이와 함께하는 이 특별한 순간은 영원히 기억될 것 같아. 지윤이의 꿈과 희망이 모두 이뤄지길 기대해. \uD83C\uDF84✨",
+        "지윤이가 오늘은 유치원 학예회에서 토끼옷을 입고 나왔다. 다들 같은 토끼옷을 입었는데도 내눈엔 지윤이밖에 안보이네♥ 지윤이의 활기찬 에너지와 특별한 빛깔이 오늘 따라 더 돋보인다. 우리 지윤이의 빛나는 미소와 춤추는 모습이 학예회를 더욱 특별하게 만들었을 거야. \uD83D\uDC30\uD83D\uDC83✨",
+        "지윤이가 오늘은 6살 생일을 맞아 유치원에서 생일파티를 했어. 특별한 날을 의미있게 보내기 위해 케이크 앞에서 초를 부는 지윤이! 이 순간이 정말 특별하다. 1년에 한 번뿐인 생일, 오늘은 지윤이가 주인공이야. 행복하고 건강한 일년이 되기를 기원해! \uD83C\uDF82\uD83C\uDF89\uD83C\uDF81",
+        "오늘은 지윤이 학예회 날! 예쁜 한복을 입고 열심히 연극하는 지윤이의 모습이 정말 인상적이다. 혹부리 영감에서 주연이 된 멋진 지윤이. 엄마도 자랑스럽네♥ 이 특별한 순간을 기억하면서 지윤이의 예술적인 모습을 응원해. \uD83C\uDFAD\uD83D\uDC4F✨",
+        "우리 진아가 태어난 지 벌써 50일! 자는 시간이 더 많은 것 같지만 바라만 봐도 행복해~ 이 작은 존재가 우리 가정에 더 많은 기쁨과 사랑을 안겨주는 우리 복덩이 진아ㅎㅎ 진아의 평화로운 모습을 바라보면서 매 순간이 정말 소중하고 특별하다는 걸 느낄 수 있어. 앞으로도 진아와 함께하는 모든 순간이 행복으로 가득하길 기원해. \uD83C\uDF19\uD83D\uDCA4\uD83D\uDC96",
+        "방금 전까지도 신나서 꺄르륵 웃던 진아였는데 피곤했는지 금새 자버렸네. 곤히 잘자는 진아가 너무 귀여워서 많이 찍어버렸다. 이 작은 순간들이 참 소중하고, 진아의 꿈 속에서 무엇을 꾸고 있는지 궁금해지네. 잠에서 깨어나면 또 새로운 모험과 기쁨이 기다리고 있을 텐데, 진아의 세상이 항상 밝고 행복하기를 기원해. \uD83C\uDF19\uD83D\uDCA4\uD83D\uDC96",
+        "엄마 등에서 한 순간도 떨어지지 않으려고 울던 진아였는데, 어느새 혼자서도 잘 앉아있네. 성장하는 모습을 보면서 기쁨과 함께 조금은 아쉬움도 느껴지는 거 같아ㅎㅎ. 그래도 진아가 세상을 탐험하며 자신의 발자취를 남기는 모습은 정말 놀라워. 앞으로 더 많은 순간들이 기다리고 있을 테니, 진아와 함께하는 모든 순간을 소중히 간직해보자. \uD83C\uDF7C\uD83D\uDC76\uD83D\uDC95",
+        "옛날에는 뒤집기도 힘들어했던 우리 진아, 이제는 곧잘 앉아있네. 앉아있을 때 보이는 조그만한 발이 너무 귀여워♥ 성장하는 모습을 지켜보면서 얼마나 빨리 자릴 찾아가고 있는지 느낄 수 있어 기쁘고 뿌듯하다. 진아의 작은 발자국이 우리 가정에 더 많은 행복을 가져다주길 바라며, 항상 건강하게 자라나길 \uD83D\uDC63\uD83D\uDC95\uD83C\uDF1F"};
+        int[] depositAmounts = {};
+        List[] images = {List.of("1"), List.of("2")};
+
+        //========= 저장 ============
+        for (int i = 0; i < N_CASH_BOX; i++) {
+            for (int j = 0; j < N_MEMORY; j++) {
+                int index = i * N_MEMORY + j;
+                Memory memory = Memory.builder()
+                        .title(titles[index])
+                        .content(contents[index])
+                        .depositAmount(depositAmounts[index])
+                        .images(images[index])
+                        .build();
+                memoryRepository.save(memory);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/memorybox/service/UserIdService.java
+++ b/src/main/java/com/memorybox/service/UserIdService.java
@@ -3,31 +3,31 @@ package com.memorybox.service;
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 @Service
 public class UserIdService {
-    private final ConcurrentLinkedQueue<Integer> userIdQueue = new ConcurrentLinkedQueue<>();
-    private final ConcurrentLinkedQueue<Integer> specialIdQueue = new ConcurrentLinkedQueue<>();
+    private static final long START_REGISTERED_USER_NUM = 1L;
+    private static final long END_REGISTERED_USER_NUM = 10L;
+
+    private final ConcurrentLinkedQueue<Long> userIdQueue = new ConcurrentLinkedQueue<>();
 
     @PostConstruct
     private void init() {
-        for (int userId = 1; userId <= 10; userId++) {
+        for (long userId = START_REGISTERED_USER_NUM; userId <= END_REGISTERED_USER_NUM; userId++) {
             userIdQueue.offer(userId);
         }
-        specialIdQueue.addAll(List.of(111, 112, 113));
     }
 
     public String getUserId() {
-        Integer userId = userIdQueue.poll();
-        userIdQueue.offer(userId);
-        return userId.toString();
-    }
+        Long userId;
+        if (userIdQueue.isEmpty()) {
+            //TODO 새로운 User 및 더미데이터 생성 후 새로운 UserId 리턴 로직 필요
+            userId = 0L;
 
-    public String getSpecialUserId() {
-        Integer userId = specialIdQueue.poll();
-        specialIdQueue.offer(userId);
+        } else {
+            userId = userIdQueue.poll();
+        }
         return userId.toString();
     }
 

--- a/src/main/java/com/memorybox/service/UserIdService.java
+++ b/src/main/java/com/memorybox/service/UserIdService.java
@@ -1,10 +1,15 @@
 package com.memorybox.service;
 
+import com.memorybox.domain.user.entity.User;
+import com.memorybox.domain.user.repository.UserRepository;
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+@RequiredArgsConstructor
 @Service
 public class UserIdService {
     private static final long START_REGISTERED_USER_NUM = 1L;
@@ -12,23 +17,26 @@ public class UserIdService {
 
     private final ConcurrentLinkedQueue<Long> userIdQueue = new ConcurrentLinkedQueue<>();
 
+    private final DummyDataService dummyDataService;
+    private final UserRepository userRepository;
+
+
     @PostConstruct
     private void init() {
+        //더미 유저 ID값을 Queue에 넣어주기
         for (long userId = START_REGISTERED_USER_NUM; userId <= END_REGISTERED_USER_NUM; userId++) {
             userIdQueue.offer(userId);
         }
     }
 
+    @Transactional
     public String getUserId() {
-        Long userId;
         if (userIdQueue.isEmpty()) {
-            //TODO 새로운 User 및 더미데이터 생성 후 새로운 UserId 리턴 로직 필요
-            userId = 0L;
-
-        } else {
-            userId = userIdQueue.poll();
+            Long userId = userRepository.save(new User()).getId();
+            dummyDataService.saveDummyData(userId);
+            return userId.toString();
         }
-        return userId.toString();
+        return userIdQueue.poll().toString();
     }
 
 }

--- a/src/main/java/com/memorybox/util/UserIdCookieUtil.java
+++ b/src/main/java/com/memorybox/util/UserIdCookieUtil.java
@@ -5,17 +5,18 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class UserIdCookieUtil {
-    public static final String MEMORYBOX_SPECIAL_USER_COOKIE = "memorybox-special-user";
+    public static final String MEMORYBOX_SPECIAL_COOKIE = "memorybox-special-user";
     public static final String MEMORYBOX_USER_ID_COOKIE = "memorybox-user-id";
     private static final long maxAgeSeconds = 60 * 60 * 24 * 30L;
 
-    public ResponseCookie makeUserIdCookie(String userId, boolean isSpecialUser) {
-        String cookieName = isSpecialUser ? MEMORYBOX_SPECIAL_USER_COOKIE : MEMORYBOX_USER_ID_COOKIE;
+    public ResponseCookie makeUserIdCookie(String userId) {
+        return ResponseCookie.from(MEMORYBOX_USER_ID_COOKIE, userId)
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
 
-        return ResponseCookie.from(cookieName, userId)
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
+    public ResponseCookie makeSpecialCookie() {
+        return ResponseCookie.from(MEMORYBOX_SPECIAL_COOKIE, "special-cookie")
                 .maxAge(maxAgeSeconds)
                 .build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,17 @@
 spring:
   application:
     name: memorybox_cert
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DB_SERVER:165.192.105.57}:${DB_PORT:30135}/${DB_NAME:memory_box}?useUnicode=true&characterEncoding=utf-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    hikari:
+      connection-timeout: 5000
+      validation-timeout: 1000
+      maximum-pool-size: 30
+      minimum-idle: 2
+      connection-test-query: SELECT 1
 
 #swagger
 springdoc:


### PR DESCRIPTION
## 변경된 인증 로직 시퀀스
1. 모든 유저는 '시작하기' 버튼을 누르고 /cert에서 userId 쿠키를 받는다.
2. 기념일 팝업을 보고 싶은 유저는 special 페이지에 url로 접속한다.
3. /special-cert API에 요청을 보내 special 쿠키를 받는다.
4. special 페이지에서 메인페이지로 보내고, 메인페이지에서 special 쿠키를 확인해서 기념일 팝업을 띄운다.

## 구현 내용
- userId쿠키가 있으면 special쿠키만 발급, 없으면 userId쿠키도 생성해서 발급.
- userId 1~10번까지는 접속 순서대로 부여.
- 이후 접속은 유저 데이터 새로 생성 후 해당 UserId 부여.
- 해당 User의 더미데이터는 비동기로 저장하여 성능 향상.
- **이후 더미데이터 내용 정해지면 코드 값에 내용 채워야 함.**

## 기타 설정
- DB 연결 코드 추가
- API 테스트를 위해 Ingress 객체 추가